### PR TITLE
Apple Silicon compatible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,14 @@ version: '3'
 services:
   contwildfly:
     build: ./wildfly
+    platform: linux/amd64
     ports:
     - "8080:8080"
     - "9990:9990"
     - "8787:8787"
   contmysql:
     build: ./mysql
+    platform: linux/amd64
     ports:
     - "3306:3306"
     


### PR DESCRIPTION
@jfrchicanog Modificación en `docker-compose.yml` para poder usar los contenedores Docker con ordenadores de la familia de chips M de Apple, como M1.

***-> ¡¡¡Mejor añadir en otra rama!!! <-***

> Solución propuesta por Juan Marqués Garrido en el foro de dudas de la asignatura Sistemas de la Información para Internet. [Stack overflow solution](https://stackoverflow.com/questions/68984133/error-failed-to-solve-with-frontend-dockerfile-v0-failed-to-create-llb-definit)